### PR TITLE
Update URL for HTTPS and context menu label to be more descriptive

### DIFF
--- a/main.js
+++ b/main.js
@@ -43,8 +43,8 @@ var windows = require("sdk/windows").browserWindows;
 var tabs = require("sdk/tabs");
 
  var menuItem = contextMenu.Item({
-  label: "DuckDuckGo...",
-  data: "http://www.duckduckgo.com/?q=",
+  label: "Search with DuckDuckGo",
+  data: "https://duckduckgo.com/?q=",
   context: contextMenu.SelectionContext(),
 
   contentScript: 'self.on("click", function (node, data) {' +


### PR DESCRIPTION
This updates the query URL to use HTTPS and drops the WWW prefix as it only adds an unnecessary roundtrip.

I also modified the label of the menu entry to be more descriptive of its function.
